### PR TITLE
Add support for strided prefix_sum

### DIFF
--- a/samples/seq/prefix_sum.cc
+++ b/samples/seq/prefix_sum.cc
@@ -21,4 +21,26 @@ int main(int argc, char* argv[]){
   auto t2 = vstl::get_dtime();
   auto size = key.size();
   cout << "time of " << size << " data: " << t2-t1 << " sec" << endl;;
+
+  cout << endl;
+
+  int mat[5][5] = {0,2,1,0,3,
+                   1,0,1,2,1,
+                   0,1,0,0,1,
+                   2,2,1,1,0,
+                   3,2,1,3,2};
+  cout << "column-wise prefix sum (scan)" << endl << "src:" << endl;
+  for(auto i=0; i<5; i++) {
+    for(auto j=0; j<5; j++) cout << mat[i][j] << " ";
+    cout << endl;
+  }
+  int out[5][5] = {0};
+  for(auto j=0; j<5; j++) {
+    vstl::seq::prefix_sum((const int*)&mat[0][j], 5, &out[0][j], 5, 5);
+  }
+  cout << "out:" << endl;
+  for(auto i=0; i<5; i++) {
+    for(auto j=0; j<5; j++) cout << out[i][j] << " ";
+    cout << endl;
+  }
 }

--- a/src/vstl/seq/core/prefix_sum.hpp
+++ b/src/vstl/seq/core/prefix_sum.hpp
@@ -12,7 +12,8 @@ namespace seq {
 
 #if defined(_SX) || defined(__ve__)
 template <class T>
-void prefix_sum(const T* valp, T* outp, size_t size) {
+void prefix_sum(const T* valp, T* outp, size_t size)
+{
   // If vector length for second part is small, do scalar
   if (size < PREFIX_SUM_VLEN * PREFIX_SUM_VLEN_MIN) {
     T current_val = 0;
@@ -66,7 +67,8 @@ void prefix_sum(const T* valp, T* outp, size_t size) {
 }
 #else
 template <class T>
-void prefix_sum(const T* valp, T* outp, size_t size) {
+void prefix_sum(const T* valp, T* outp, size_t size)
+{
   T current_val = 0;
   for(size_t j = 0; j < size; j++) {
     auto loaded_v = valp[j];
@@ -77,8 +79,82 @@ void prefix_sum(const T* valp, T* outp, size_t size) {
 }
 #endif
 
+#if defined(_SX) || defined(__ve__)
 template <class T>
-std::vector<T> prefix_sum(const std::vector<T>& val) {
+void prefix_sum(const T* valp, const size_t val_stride,
+                T* outp, const size_t out_stride,
+                size_t size)
+{
+  // If vector length for second part is small, do scalar
+  if (size < PREFIX_SUM_VLEN * PREFIX_SUM_VLEN_MIN) {
+    T current_val = 0;
+    // no vector loop
+    for(size_t j = 0; j < size; j++) {
+      auto loaded_v = valp[j * val_stride];
+      auto next_val = loaded_v + current_val;
+      outp[j * out_stride] = next_val;
+      current_val = next_val;
+    }
+    return;
+  }
+  // do vectorized version of prefix_sum
+  size_t each = size / PREFIX_SUM_VLEN;
+  if(each % 2 == 0 && each > 1) each--;
+  size_t rest = size - each * PREFIX_SUM_VLEN;
+  T current_val[PREFIX_SUM_VLEN];
+#pragma _NEC vreg(current_val)
+  for(int i = 0; i < PREFIX_SUM_VLEN; i++) {
+    current_val[i] = 0;
+  }
+  // each should always be >= 1
+  for(size_t j = 0; j < each; j++) {
+    for(size_t i = 0; i < PREFIX_SUM_VLEN; i++) {
+      auto loaded_v = valp[(j + each * i) * val_stride];
+      auto next_val = loaded_v + current_val[i];
+      outp[(j + each * i) * out_stride] = next_val;
+      current_val[i] = next_val;
+    }
+  }
+  size_t rest_idx_start = each * PREFIX_SUM_VLEN;
+  T current_val_rest = 0;
+  for(size_t j = 0; j < rest; j++) {
+    auto loaded_v = valp[(j + rest_idx_start) * val_stride];
+    auto next_val = loaded_v + current_val_rest;
+    outp[(j + rest_idx_start) * out_stride] = next_val;
+    current_val_rest = next_val;
+  }
+  for(size_t i = 1; i < PREFIX_SUM_VLEN; i++) {
+    T to_add = outp[(each * i - 1) * out_stride];
+    for(size_t j = each * i; j < each * (i+1); j++) {
+      outp[j * out_stride] += to_add;
+    }
+  }
+  T to_add = outp[(each * PREFIX_SUM_VLEN - 1) * out_stride];
+  for(size_t j = each * PREFIX_SUM_VLEN;
+      j < each * PREFIX_SUM_VLEN + rest; j++) {
+    outp[j * out_stride] += to_add;
+  }
+  return;
+}
+#else
+template <class T>
+void prefix_sum(const T* valp, const size_t val_stride,
+                T* outp, const size_t out_stride,
+                size_t size)
+{
+  T current_val = 0;
+  for(size_t j = 0; j < size; j++) {
+    auto loaded_v = valp[j * val_stride];
+    auto next_val = loaded_v + current_val;
+    outp[j * out_stride] = next_val;
+    current_val = next_val;
+  }
+}
+#endif
+
+template <class T>
+std::vector<T> prefix_sum(const std::vector<T>& val)
+{
   size_t size = val.size();
   if(size == 0) {return std::vector<T>();}
   std::vector<T> out(size);


### PR DESCRIPTION
This allows us to use it for matrix columns, as well. I.e. sort each column of a matrix.